### PR TITLE
Improve the workflows

### DIFF
--- a/.github/workflows/CI build.yml
+++ b/.github/workflows/CI build.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      # Setup the jdk using version 11 of temurin
-      - name: Setup java 11 using temurin
+      # Setup the jdk using version 11 of Adoptium Temurin
+      - name: Setup java 11 using Adoptium Temurin
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
@@ -41,7 +41,7 @@ jobs:
         id: changes
         with:
           filters: |
-            changelog:
+            changelog: 
               - 'docs/CHANGELOG.md'
             sources:
               - '**/pom.xml'

--- a/.github/workflows/CI build.yml
+++ b/.github/workflows/CI build.yml
@@ -2,10 +2,10 @@ name: CI build
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: ['**']
   workflow_run:
     workflows: ["CI release"]
-    branches: [ main ]
+    branches: [ '**' ]
     types:
       - completed
   workflow_dispatch:
@@ -33,7 +33,7 @@ jobs:
       #   - compile : compile the source code.
       #   - test : Perform the tests.
       - name: Build
-        run: mvn -ntp clean validate compile test javadoc:test-javadoc
+        run: mvn -ntp clean validate compile test javadoc:test-javadoc javadoc:jar
 
       # Check changelog update
       - name: Check changelog update
@@ -43,7 +43,13 @@ jobs:
           filters: |
             changelog:
               - 'docs/CHANGELOG.md'
+            sources:
+              - '**/pom.xml'
+              - '**/README.md'
+              - '**/src/**'
         if: github.event_name != 'workflow_dispatch'
 
-      - if: steps.changes.outputs.changelog == 'false' && github.event_name != 'workflow_dispatch'
-        run: exit 1
+      - if: steps.changes.outputs.changelog == 'false' && github.event_name != 'workflow_dispatch' && steps.changes.outputs.sources == 'true'
+        run: |
+          echo "Please update the Changelog.md file."
+          exit 1

--- a/.github/workflows/CI release.yml
+++ b/.github/workflows/CI release.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      # Setup the jdk using version 11 of temurin
-      - name: Java setup
+      # Setup the jdk using version 11 of Adoptium Temurin
+      - name: Setup java 11 using Adoptium Temurin
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
@@ -101,5 +101,7 @@ jobs:
             echo "Minor or Major change"
             BRANCH="${SPLIT0[0]}.${SPLIT0[1]}.X"
             git checkout -b "$BRANCH" "v${GIT_TAG}"
+            mvn versions:set -DnewVersion="${SPLIT0[0]}.${SPLIT0[1]}.$((${SPLIT0[2]}+1))-SNAPSHOT"
+            git commit -a -m "Set next version."
             git push -u origin "$BRANCH"
           fi

--- a/.github/workflows/CI release.yml
+++ b/.github/workflows/CI release.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Test build
       - name: Build test
-        run: mvn -ntp clean validate compile test javadoc:test-javadoc
+        run: mvn -ntp clean validate compile test javadoc:test-javadoc javadoc:jar
 
       # Create the release :
       #   - move from Snapshot version to Release

--- a/.github/workflows/CI snapshot.yml
+++ b/.github/workflows/CI snapshot.yml
@@ -2,10 +2,10 @@ name: CI snapshot
 
 on:
   push:
-    branches: [ main ]
+    branches: [ '**' ]
   workflow_run:
     workflows: ["CI release"]
-    branches: [ main ]
+    branches: [ '**' ]
     types:
       - completed
   workflow_dispatch:

--- a/.github/workflows/CI snapshot.yml
+++ b/.github/workflows/CI snapshot.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      # Setup the jdk using version 11 of temurin
-      - name: Java setup
+      # Setup the jdk using version 11 of Adoptium Temurin
+      - name: Setup java 11 using Adoptium Temurin
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'


### PR DESCRIPTION
Improve the workflows in order to build any branch, move to snapshot on branch fork and require changelog update only when modifying a source/pom/readme file.